### PR TITLE
Update sourcecred.json

### DIFF
--- a/sourcecred.json
+++ b/sourcecred.json
@@ -5,8 +5,131 @@
       "id": "sourcecred/discord",
       "configsByTarget": {
         "453243919774253079": [
-          {
-            "memo": "Initial Config",
+          { "memo": "Initial Config",
+            "startDate": "3/1/2022",
+            "weights": [
+              {
+                "key": "emoji",
+                "default": 0,
+                "subkeys": [
+                  {
+                    "subkey": ":value2:",
+                    "weight": 2
+                  },
+                  {
+                    "subkey": ":value3:",
+                    "weight": 3
+                  },
+                  {
+                    "subkey": ":value5:",
+                    "weight": 5
+                  },
+                  {
+                    "subkey": ":value8:",
+                    "weight": 8
+                  },
+                  {
+                    "subkey": ":value13:",
+                    "weight": 13
+                  },
+                  {
+                    "subkey": "sourcecred:626763367893303303",
+                    "weight": 3
+                  },
+                  {
+                    "subkey": "👎",
+                    "weight": 0
+                  }
+                ]
+              },
+              {
+                "key": "role",
+                "default": 0,
+                "subkeys": [
+                  {
+                    "subkey": "477551557723029514",
+                    "memo": "contributors",
+                    "weight": 2
+                  },
+                  {
+                    "subkey": "717905734863421472",
+                    "memo": "community",
+                    "weight": 1
+                  }
+                ]
+              },
+              {
+                "key": "channel",
+                "default": 1,
+                "subkeys": [
+                  {
+                    "subkey": "743545520445718700",
+                    "memo": "meeting-notes",
+                    "weight": 8
+                  },
+                  {
+                    "subkey": "718512695875469353",
+                    "memo": "announcements",
+                    "weight": 0.1
+                  },
+                  {
+                    "subkey": "454007860926611478",
+                    "memo": "any-questions",
+                    "weight": 3
+                  },
+                  {
+                    "subkey": "679064720375808026",
+                    "memo": "props",
+                    "weight": 15
+                  },
+                  {
+                    "subkey": "543168537062014987",
+                    "memo": "did-a-thing",
+                    "weight": 12
+                  }
+                ]
+              },
+              {
+                "key": "category",
+                "default": 1,
+                "subkeys": []
+              }
+            ],
+            "operators": [
+              {
+                "key": "reactionsAcrossParticipants",
+                "operator": "AVERAGE"
+              },
+              {
+                "key": "reactionsOfSingleParticipant",
+                "operator": "MAX"
+              }
+            ],
+            "shares": [
+              {
+                "key": "author",
+                "default": 1,
+                "subkeys": [
+                  {
+                    "subkey": "743545520445718700",
+                    "memo": "meeting-notes",
+                    "weight": 0.05
+                  },
+                  {
+                    "subkey": "679064720375808026",
+                    "memo": "props",
+                    "weight": 0
+                  }
+                ]
+              },
+              {
+                "key": "mention",
+                "default": 1,
+                "subkeys": []
+              }
+              ]
+          },
+            { "memo": "Initial Config",
             "startDate": "1/1/2021",
             "weights": [
               {
@@ -127,6 +250,7 @@
                 "key": "mention",
                 "default": 1,
                 "subkeys": []
+              
               }
             ]
           }


### PR DESCRIPTION
Change default emoji weights from 1 to 0 beginning March 1, 2022 (or whenever the new cred emojis are live. In this way our Cred weighting can be more intentional and other emoji reacts can still act as signals, boosts, and emotional responses without being used as and influencing Cred unintentionally.




-----
### Resources for Reviewers
[Human-Readable Ledger Diff](https://observablehq.com/@sourcecred/sourcecred-ledger-viewer?repo=sourcecred/cred)

[Grain Sale Request Spreadsheet](https://docs.google.com/spreadsheets/d/1emY35TXD5fiCZJFZooPy-NjvchzFDoiWDw8LJMXT_Es/edit#gid=156078179)

[Opt-in Spreadsheet](https://docs.google.com/spreadsheets/d/1Az-Cew-rFG9S6Yo55GnjNIy7bssHvtrTtF45yeoxFtw/edit#gid=1048967430)
